### PR TITLE
Adding ddtrace logger to DatadogLogger by default

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@ History
 =======
 
 
+v0.9.1 (2020-11-17)
+-----------------------
+
+* Add ddtrace logger to DatadogLogger by default saving the user having to pass this info on their side.
+
+
 v0.9.0 (2020-11-17)
 -----------------------
 

--- a/aioradio/logger.py
+++ b/aioradio/logger.py
@@ -47,7 +47,7 @@ class DatadogLogger():
         self.logger = logging.getLogger(main_logger)
         self.logger.setLevel(log_level)
         self.log_level = log_level
-        self.datadog_loggers = set(datadog_loggers) if datadog_loggers else []
+        self.datadog_loggers = set(datadog_loggers + ['ddtrace']) if datadog_loggers else ['ddtrace']
         self.format = log_format
         self.add_handlers()
 

--- a/aioradio/requirements.txt
+++ b/aioradio/requirements.txt
@@ -2,7 +2,7 @@ aioboto3==8.0.5
 aiobotocore==1.1.2
 aiojobs==0.2.2
 aioredis==1.3.1
-ddtrace==0.43.1
+ddtrace==0.44.0
 fakeredis==1.4.4
 flask==1.1.2
 httpx==0.16.1

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as fileobj:
     long_description = fileobj.read()
 
 setup(name='aioradio',
-    version='0.9.0',
+    version='0.9.1',
     description='Generic asynchronous i/o python utilities for AWS services (SQS, S3, DynamoDB, Secrets Manager), Redis, MSSQL (pyodbc), JIRA and more',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
v0.9.1 (2020-11-17)
-----------------------

* Add ddtrace logger to DatadogLogger by default saving the user having to pass this info on their side.
