### PR TITLE
Fix syntax in manage_async_tasks

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@ History
 =======
 
 
+v0.11.7 (2021-03-01)
+-----------------------
+
+* Fix syntax error in manage_async_tasks where append should be equal symbol.
+
+
 v0.11.6 (2021-03-01)
 -----------------------
 

--- a/aioradio/utils.py
+++ b/aioradio/utils.py
@@ -1,11 +1,12 @@
 """aioradio utils cache script."""
 
-from asyncio import create_task, to_thread, sleep, coroutine
+from asyncio import coroutine, create_task, sleep, to_thread
 from typing import Any, Dict, List, Tuple
 
+
 async def manage_async_tasks(items: List[Tuple[coroutine, str]], concurrency: int) -> Dict[str, Any]:
-    """Manages a grouping of async tasks, keeping number of active tasks at
-    the concurrency level by starting new tasks whenver one completes.
+    """Manages a grouping of async tasks, keeping number of active tasks at the
+    concurrency level by starting new tasks whenver one completes.
 
     Args:
         items (List[Dict[str, Any]]): List of tuples (coroutine, name)
@@ -26,7 +27,7 @@ async def manage_async_tasks(items: List[Tuple[coroutine, str]], concurrency: in
                 results[task.get_name()] = await task
                 if count < num_of_items:
                     coro, name = items[count]
-                    arr[index].append(create_task(coro) if name is None else create_task(coro, name=name))
+                    arr[index] = create_task(coro) if name is None else create_task(coro, name=name)
                     count += 1
 
     return results

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as fileobj:
     long_description = fileobj.read()
 
 setup(name='aioradio',
-    version='0.11.6',
+    version='0.11.7',
     description='Generic asynchronous i/o python utilities for AWS services (SQS, S3, DynamoDB, Secrets Manager), Redis, MSSQL (pyodbc), JIRA and more',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
v0.11.7 (2021-03-01)
-----------------------

* Fix syntax error in manage_async_tasks where append should be equal symbol.