### PR TITLE
Allow {ODBC Driver 17 for SQL Server} to work w/ linux

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@ History
 =======
 
 
+v0.13.9 (2021-06-03)
+
+* Add SQL Server 2017 driver path for Debian operating systems.
+
+
 v0.13.8 (2021-06-02)
 
 * Add application_intent & tds_version as pyodbc connection options.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as fileobj:
     long_description = fileobj.read()
 
 setup(name='aioradio',
-    version='0.13.8',
+    version='0.13.9',
     description='Generic asynchronous i/o python utilities for AWS services (SQS, S3, DynamoDB, Secrets Manager), Redis, MSSQL (pyodbc), JIRA and more',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
v0.13.9 (2021-06-03)

* Add SQL Server 2017 driver path for Debian operating systems.