### PR TITLE
Update post params usage to data

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@ History
 =======
 
 
+v0.13.17 (2021-07-21)
+
+* Update long running jobs callback to use data instead of params in post
+
+
 v0.13.16 (2021-07-21)
 
 * Update boto3==1.16.52.

--- a/aioradio/long_running_jobs.py
+++ b/aioradio/long_running_jobs.py
@@ -217,7 +217,7 @@ class LongRunningJobs:
 
             # Send results via POST request if necessary
             if callback_url:
-                create_task(self.httpx_client.post(callback_url, params={'results': data, 'uuid': body['uuid']}, timeout=30))
+                create_task(self.httpx_client.post(callback_url, data={'results': data, 'uuid': body['uuid']}, timeout=30))
 
             # Update the hashed UUID with processing results
             await self.cache.hmset(
@@ -265,7 +265,7 @@ class LongRunningJobs:
 
             # Send results via POST request if necessary
             if callback_url:
-                create_task(self.httpx_client.post(callback_url, params={'results': data, 'uuid': body['uuid']}, timeout=30))
+                create_task(self.httpx_client.post(callback_url, data={'results': data, 'uuid': body['uuid']}, timeout=30))
 
             # Update the hashed UUID with processing results
             await self.cache.hmset(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as fileobj:
     long_description = fileobj.read()
 
 setup(name='aioradio',
-    version='0.13.16',
+    version='0.13.17',
     description='Generic asynchronous i/o python utilities for AWS services (SQS, S3, DynamoDB, Secrets Manager), Redis, MSSQL (pyodbc), JIRA and more',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
v0.13.17 (2021-07-21)

* Update long running jobs callback to use data instead of params in post