### PR TITLE
Relaxed aioboto3, aiobotocore & boto3 version requirements

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@ History
 =======
 
 
+v0.14.1 (2021-07-22)
+
+* Relaxed aioboto3, aiobotocore & boto3 version requirements to work with python3.7 since new versions of aioboto3 are limited to python3.8+.
+
+
 v0.14.0 (2021-07-22)
 
 * Update aioboto3==9.1.0, aiobotocore==1.3.3, boto3==1.17.106 & moto==2.1.0.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as fileobj:
     long_description = fileobj.read()
 
 setup(name='aioradio',
-    version='0.14.0',
+    version='0.14.1',
     description='Generic asynchronous i/o python utilities for AWS services (SQS, S3, DynamoDB, Secrets Manager), Redis, MSSQL (pyodbc), JIRA and more',
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -19,10 +19,10 @@ setup(name='aioradio',
         'aioradio/aws',
     ],
     install_requires=[
-        'aioboto3==9.1.0',
-        'aiobotocore==1.3.3',
+        'aioboto3>=9.0.0',
+        'aiobotocore>=1.3.1',
         'aiojobs==0.3.0',
-        'boto3==1.17.106',
+        'boto3>=1.17.49',
         'ddtrace==0.50.1',
         'fakeredis==1.5.2',
         'httpx==0.18.2',


### PR DESCRIPTION
v0.14.1 (2021-07-22)

* Relaxed aioboto3, aiobotocore & boto3 version requirements to work with python3.7 since new versions of aioboto3 are limited to python3.8+.
