### PR TITLE
Fix import of establish_pyodbc_connection

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+
+v0.15.5 (2021-11-02)
+
+* Fix import of establish_pyodbc_connection to not check sys.modules for pyodbc.
+
+
 v0.15.4 (2021-11-01)
 
 * Dates and years checks now use values from constants and we do not need to pass min/max into the corresponding functions:

--- a/aioradio/file_ingestion.py
+++ b/aioradio/file_ingestion.py
@@ -19,7 +19,6 @@ import json
 import logging
 import os
 import re
-import sys
 import time
 import zipfile
 from asyncio import sleep
@@ -1069,9 +1068,7 @@ def async_db_wrapper(db_info: List[Dict[str, Any]]) -> Any:
                     if item['db'] == 'pyodbc':
                         # Add import here because it requires extra dependencies many systems
                         # don't have out of the box so only import when explicitly being used
-                        if 'pyodbc' not in sys.modules:
-                            from aioradio.pyodbc import \
-                                establish_pyodbc_connection
+                        from aioradio.pyodbc import establish_pyodbc_connection
                         conns[item['name']] = await establish_pyodbc_connection(**creds, autocommit=False)
                     elif item['db'] == 'psycopg2':
                         conns[item['name']] = await establish_psycopg2_connection(**creds)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as fileobj:
     long_description = fileobj.read()
 
 setup(name='aioradio',
-    version='0.15.4',
+    version='0.15.5',
     description='Generic asynchronous i/o python utilities for AWS services (SQS, S3, DynamoDB, Secrets Manager), Redis, MSSQL (pyodbc), JIRA and more',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
v0.15.5 (2021-11-02)

* Fix import of establish_pyodbc_connection to not check sys.modules for pyodbc.