### PR TITLE
fix reference to wrong aiobotocore version

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 v0.17.4 (2022-03-25)
 
 * Update aioboto3==9.4.0
-* Update aiobotocore==2.2.0
+* Update aiobotocore==2.1.2
 
 
 v0.17.3 (2022-02-18)


### PR DESCRIPTION
v0.17.4 (2022-03-25)

* Update aioboto3==9.4.0
* Update aiobotocore==2.1.2