### PR TITLE
removed ip_address param from get_ftp_connection

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,16 +3,23 @@ History
 =======
 
 
+v0.17.6 (2022-04-14)
+
+* Remove ip parameters from ds_utils function get_ftp_connection.
+* Update ddtrace==1.0.0.
+* Update pandas==1.4.2.
+
+
 v0.17.5 (2022-03-31)
 
-* Update aioboto3==9.5.0
-* Update aiobotocore==2.2.0
+* Update aioboto3==9.5.0.
+* Update aiobotocore==2.2.0.
 
 
 v0.17.4 (2022-03-25)
 
-* Update aioboto3==9.4.0
-* Update aiobotocore==2.1.2
+* Update aioboto3==9.4.0.
+* Update aiobotocore==2.1.2.
 
 
 v0.17.3 (2022-02-18)

--- a/aioradio/ds_utils.py
+++ b/aioradio/ds_utils.py
@@ -174,13 +174,13 @@ def get_s3_pickle_to_object(s3_client, s3_bucket, key):
     return data
 
 
-def get_ftp_connection(secret_id, ip_address, port=139):
+def get_ftp_connection(secret_id, port=139):
     """Get SMB Connection."""
 
     secret_client = get_boto3_session(ENV).client("secretsmanager", region_name='us-east-1')
     creds = json.loads(secret_client.get_secret_value(SecretId=secret_id)['SecretString'])
     conn = SMBConnection(creds['user'], creds['password'], secret_id, creds['server'], use_ntlm_v2=True)
-    conn.connect(ip_address, port)
+    conn.connect(creds['server'], port)
 
     return conn
 

--- a/aioradio/requirements.txt
+++ b/aioradio/requirements.txt
@@ -2,7 +2,7 @@ aioboto3==9.5.0
 aiobotocore==2.2.0
 aiojobs==0.3.0
 boto3==1.21.21
-ddtrace==0.60.1
+ddtrace==1.0.0
 dominodatalab==1.0.7
 fakeredis==1.7.1
 flask==2.1.1
@@ -11,7 +11,7 @@ httpx==0.22.0
 mandrill==1.0.60
 moto==3.0.3
 orjson==3.6.7
-pandas==1.4.1
+pandas==1.4.2
 pre-commit==2.17.0
 psycopg2-binary==2.9.3
 pylint==2.13.4

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as fileobj:
     long_description = fileobj.read()
 
 setup(name='aioradio',
-    version='0.17.5',
+    version='0.17.6',
     description='Generic asynchronous i/o python utilities for AWS services (SQS, S3, DynamoDB, Secrets Manager), Redis, MSSQL (pyodbc), JIRA and more',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
v0.17.6 (2022-04-14)

* Remove ip parameters from ds_utils function get_ftp_connection.
* Update ddtrace==1.0.0.
* Update pandas==1.4.2.