### PR TITLE
fix issue with writing excel data to s3

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,16 @@ History
 =======
 
 
+v0.17.22 (2022-11-17)
+
+* Fix issue with writing excel data to s3 for data ingestion project.
+* Update dominodatalab==1.2.1.
+* Update fakeredis==1.10.1.
+* Update pyodbc==4.0.35.
+* Update pytest-asyncio==0.20.2.
+* Update wheel==0.38.4.
+
+
 v0.17.21 (2022-11-08)
 
 * Add zipfile to tsv/csv file function in file_ingestion.py.

--- a/aioradio/file_ingestion.py
+++ b/aioradio/file_ingestion.py
@@ -1811,6 +1811,7 @@ async def tsv_to_s3(records: str, delimiter: str, s3_bucket: str, s3_key: str):
     with NamedTemporaryFile(mode='w') as tmp:
         writer = csv.writer(tmp, delimiter=delimiter)
         writer.writerows(records)
+        tmp.seek(0)
         await upload_file(bucket=s3_bucket, filepath=tmp.name, s3_key=s3_key)
 
 

--- a/aioradio/requirements.txt
+++ b/aioradio/requirements.txt
@@ -6,8 +6,8 @@ boto3==1.24.59
 botocore==1.27.59
 cchardet==2.1.7
 ddtrace==1.3.6
-dominodatalab==1.2.0
-fakeredis==1.9.4
+dominodatalab==1.2.1
+fakeredis==1.10.1
 flask==2.1.2
 flask-cors==3.0.10
 httpx==0.23.0
@@ -19,13 +19,13 @@ pandas==1.4.4
 pre-commit==2.20.0
 psycopg2-binary==2.9.3
 pylint==2.15.5
-pyodbc==4.0.34
+pyodbc==4.0.35
 pysmb==1.2.8
 pytest==7.2.0
-pytest-asyncio==0.20.1
+pytest-asyncio==0.20.2
 pytest-cov==4.0.0
 python-json-logger==2.0.4
 redis==3.5.3
 twine==4.0.1
 werkzeug==2.1.2
-wheel==0.37.1
+wheel==0.38.4

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as fileobj:
     long_description = fileobj.read()
 
 setup(name='aioradio',
-    version='0.17.21',
+    version='0.17.22',
     description='Generic asynchronous i/o python utilities for AWS services (SQS, S3, DynamoDB, Secrets Manager), Redis, MSSQL (pyodbc), JIRA and more',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
v0.17.22 (2022-11-17)

* Fix issue with writing excel data to s3 for data ingestion project.
* Update dominodatalab==1.2.1.
* Update fakeredis==1.10.1.
* Update pyodbc==4.0.35.
* Update pytest-asyncio==0.20.2.
* Update wheel==0.38.4.