### PR TITLE
Fix overwrite of delimiter parameter value

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,15 @@ History
 =======
 
 
+v0.17.24 (2022-12-01)
+
+* Fix overwrite of delimiter parameter value in zipfile_to_tsv function.
+* Update httpx==0.23.1.
+* Update orjson==3.8.2.
+* Update pylint==2.15.7.
+* Update twine==4.0.2.
+
+
 v0.17.23 (2022-11-30)
 
 * Add account_id argument to SQS functions for cross account functionality.

--- a/aioradio/file_ingestion.py
+++ b/aioradio/file_ingestion.py
@@ -1697,10 +1697,10 @@ async def zipfile_to_tsv(
                         encodings = [encoding] + [i for i in ['UTF-8', 'LATIN-1', 'UTF-16'] if i != encoding]
                         for encoding in encodings:
                             try:
-                                delimiter = detect_delimiter(path, encoding)
-                                if delimiter:
+                                detected_delimiter = detect_delimiter(path, encoding)
+                                if detected_delimiter:
                                     try:
-                                        records_from_path, header = tsv_to_records(path, encoding, delimiter, header)
+                                        records_from_path, header = tsv_to_records(path, encoding, detected_delimiter, header)
                                         records.extend(records_from_path)
                                         break
                                     except Exception as err:

--- a/aioradio/requirements.txt
+++ b/aioradio/requirements.txt
@@ -10,15 +10,15 @@ dominodatalab==1.2.1
 fakeredis==1.10.1
 flask==2.1.2
 flask-cors==3.0.10
-httpx==0.23.0
+httpx==0.23.1
 mandrill==1.0.60
 moto==3.1.18
 openpyxl==3.0.10
-orjson==3.8.1
+orjson==3.8.2
 pandas==1.4.4
 pre-commit==2.20.0
 psycopg2-binary==2.9.3
-pylint==2.15.5
+pylint==2.15.7
 pyodbc==4.0.35
 pysmb==1.2.8
 pytest==7.2.0
@@ -26,6 +26,6 @@ pytest-asyncio==0.20.2
 pytest-cov==4.0.0
 python-json-logger==2.0.4
 redis==3.5.3
-twine==4.0.1
+twine==4.0.2
 werkzeug==2.1.2
 wheel==0.38.4

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as fileobj:
     long_description = fileobj.read()
 
 setup(name='aioradio',
-    version='0.17.23',
+    version='0.17.24',
     description='Generic asynchronous i/o python utilities for AWS services (SQS, S3, DynamoDB, Secrets Manager), Redis, MSSQL (pyodbc), JIRA and more',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
v0.17.24 (2022-12-01)

* Fix overwrite of delimiter parameter value in zipfile_to_tsv function.
* Update httpx==0.23.1.
* Update orjson==3.8.2.
* Update pylint==2.15.7.
* Update twine==4.0.2.