### PR TITLE
Only import domino within domino specific functions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@ History
 =======
 
 
+v0.19.0 (2023-09-07)
+
+* Only import domino within domino specific functions so it doesn't need to be installed when using ds_utils.
+* Improve logging in ds_utils to log with timestamp before message.
+
+
 v0.18.5 (2023-08-31)
 
 * Remove dominodatalab as an install dependency.

--- a/aioradio/ds_utils.py
+++ b/aioradio/ds_utils.py
@@ -22,13 +22,18 @@ from time import sleep, time
 
 import boto3
 import pandas as pd
-from domino import Domino
 from smb.SMBConnection import SMBConnection
 
 warnings.simplefilter(action='ignore', category=UserWarning)
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
 MAX_SSL_CONTENT_LENGTH = (2 ** 31) - 1
+
+logger = logging.getLogger(__name__)
+logger.propagate = False
+c_handler = logging.StreamHandler()
+c_handler.setLevel(logging.INFO)
+c_format = logging.Formatter('%(asctime)s:   %(message)s')
+c_handler.setFormatter(c_format)
+logger.addHandler(c_handler)
 
 
 def file_to_s3(s3_client, local_filepath, s3_bucket, key):
@@ -256,6 +261,7 @@ def get_boto3_session(env):
 def get_domino_connection(secret_id, project, host, env='sandbox'):
     """Get domino connection."""
 
+    from domino import Domino
     secret_client = get_boto3_session(env).client("secretsmanager", region_name='us-east-1')
     api_key = secret_client.get_secret_value(SecretId=secret_id)['SecretString']
     return Domino(project=project, api_key=api_key, host=host)

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,12 @@ with open('README.md', 'r') as fileobj:
     long_description = fileobj.read()
 
 setup(name='aioradio',
-    version='0.18.5',
+    version='0.19.0',
     description='Generic asynchronous i/o python utilities for AWS services (SQS, S3, DynamoDB, Secrets Manager), Redis, MSSQL (pyodbc), JIRA and more',
     long_description=long_description,
     long_description_content_type="text/markdown",
     url='https://github.com/nrccua/aioradio',
-    author='NRCCUA Architects',
+    author='Encoura DS Team',
     author_email='tim.reichard@encoura.org',
     license="MIT",
     packages=[


### PR DESCRIPTION
v0.19.0 (2023-09-07)

* Only import domino within domino specific functions so it doesn't need to be installed when using ds_utils.
* Improve logging in ds_utils to log with timestamp before message.