### PR TITLE
Add TrustServerCertificate option in sqlserver connection string

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@ History
 =======
 
 
+v0.19.3 (2023-10-20)
+
+* Add TrustServerCertificate option in sqlserver connection string, enabling use of driver {ODBC Driver 18 for SQL Server}.
+
+
 v0.19.2 (2023-10-19)
 
 * Add new DB_CONNECT class that uses env vars instead of AWS secret manager for sensitive creds.

--- a/aioradio/pyodbc.py
+++ b/aioradio/pyodbc.py
@@ -49,6 +49,7 @@ def establish_pyodbc_connection(
         database: str='',
         tds_version: str='7.4',
         trusted_connection: str='',
+        trust_server_certificate: str='',
         multi_subnet_failover: str='',
         driver: str='',
         application_intent: str='',
@@ -65,6 +66,7 @@ def establish_pyodbc_connection(
         database (str, optional): database. Defaults to ''.
         tds_version (str, optional): TDS_Version. Defaults to '7.4'.
         trusted_connection (str, optional): Trusted_Connection. Defaults to ''.
+        trust_server_certificate (str, optional): TrustServerCertificate. Defaults to ''.
         multi_subnet_failover (str, optional): MultiSubnetFailover. Defaults to ''.
         driver (str, optional): unixodbc driver. Defaults to ''.
         application_intent (str, optional): ReadOnly | ReadWrite. Defaults to ''.
@@ -98,6 +100,8 @@ def establish_pyodbc_connection(
         conn_string += f';MultiSubnetFailover={multi_subnet_failover}'
     if application_intent:
         conn_string += f';ApplicationIntent={application_intent}'
+    if trust_server_certificate:
+        conn_string += f';TrustServerCertificate={trust_server_certificate}'
 
     return pyodbc.connect(conn_string, autocommit=autocommit)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as fileobj:
     long_description = fileobj.read()
 
 setup(name='aioradio',
-    version='0.19.2',
+    version='0.19.3',
     description='Generic asynchronous i/o python utilities for AWS services (SQS, S3, DynamoDB, Secrets Manager), Redis, MSSQL (pyodbc), JIRA and more',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
v0.19.3 (2023-10-20)

* Add TrustServerCertificate option in sqlserver connection string, enabling use of driver {ODBC Driver 18 for SQL Server}.