### PR TITLE
Add sqs.sync_add_regions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@ History
 =======
 
 
+v0.20.1 (2023-11-16)
+
+* Add sqs.sync_add_regions for setting region besides us-east-1 during instantiation of LongRunningJobs.
+
+
 v0.20.0 (2023-11-06)
 
 * Update redis==5.0.1.

--- a/aioradio/aws/sqs.py
+++ b/aioradio/aws/sqs.py
@@ -25,6 +25,16 @@ async def add_regions(regions: List[str]):
     AWS_SERVICE.add_regions(regions)
 
 
+def sync_add_regions(regions: List[str]):
+    """Add regions to SQS AWS service.
+
+    Args:
+        regions (List[str]): List of AWS regions
+    """
+
+    AWS_SERVICE.add_regions(regions)
+
+
 @AWS_SERVICE.active
 async def create_queue(queue: str, region: str, attributes: Dict[str, str], account_id: str='') -> Dict[str, Any]:
     """Create SQS queue in region defined.

--- a/aioradio/long_running_jobs.py
+++ b/aioradio/long_running_jobs.py
@@ -51,6 +51,7 @@ class LongRunningJobs:
     # define the queue name and aws region
     sqs_queue: str = None
     sqs_region: str = None
+    sqs.sync_add_regions([sqs_region])
 
     # If running test cases use fakeredis
     fakeredis: bool = False

--- a/aioradio/requirements.txt
+++ b/aioradio/requirements.txt
@@ -16,8 +16,8 @@ mandrill==1.0.60
 moto==3.1.18
 openpyxl==3.0.10
 orjson==3.8.10
-pandas==2.1.2
-polars==0.19.12
+pandas==2.1.3
+polars==0.19.13
 pre-commit==3.5.0
 psycopg2-binary==2.9.9
 pyarrow==13.0.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as fileobj:
     long_description = fileobj.read()
 
 setup(name='aioradio',
-    version='0.20.0',
+    version='0.20.1',
     description='Generic asynchronous i/o python utilities for AWS services (SQS, S3, DynamoDB, Secrets Manager), Redis, MSSQL (pyodbc), JIRA and more',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
v0.20.1 (2023-11-16)

* Add sqs.sync_add_regions for setting region besides us-east-1 during instantiation of LongRunningJobs.