### PR TITLE
Hard-code 'us-east-1' and 'us-east-2' as regions in SQS AwsServiceMan…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@ History
 =======
 
 
+v0.20.2 (2023-11-16)
+
+* Hard-code 'us-east-1' and 'us-east-2' as regions in SQS AwsServiceManager.
+
+
 v0.20.1 (2023-11-16)
 
 * Add sqs.sync_add_regions for setting region besides us-east-1 during instantiation of LongRunningJobs.

--- a/aioradio/aws/sqs.py
+++ b/aioradio/aws/sqs.py
@@ -11,21 +11,11 @@ from botocore.exceptions import ClientError
 from aioradio.aws.utils import AwsServiceManager
 
 LOG = logging.getLogger(__name__)
-AWS_SERVICE = AwsServiceManager(service='sqs', regions=['us-east-1'])
+AWS_SERVICE = AwsServiceManager(service='sqs', regions=['us-east-1', 'us-east-2'])
 SQS = AWS_SERVICE.service_dict
 
 
 async def add_regions(regions: List[str]):
-    """Add regions to SQS AWS service.
-
-    Args:
-        regions (List[str]): List of AWS regions
-    """
-
-    AWS_SERVICE.add_regions(regions)
-
-
-def sync_add_regions(regions: List[str]):
     """Add regions to SQS AWS service.
 
     Args:

--- a/aioradio/long_running_jobs.py
+++ b/aioradio/long_running_jobs.py
@@ -51,7 +51,6 @@ class LongRunningJobs:
     # define the queue name and aws region
     sqs_queue: str = None
     sqs_region: str = None
-    sqs.sync_add_regions([sqs_region])
 
     # If running test cases use fakeredis
     fakeredis: bool = False

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as fileobj:
     long_description = fileobj.read()
 
 setup(name='aioradio',
-    version='0.20.1',
+    version='0.20.2',
     description='Generic asynchronous i/o python utilities for AWS services (SQS, S3, DynamoDB, Secrets Manager), Redis, MSSQL (pyodbc), JIRA and more',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
v0.20.2 (2023-11-16)

* Hard-code 'us-east-1' and 'us-east-2' as regions in SQS AwsServiceManager.