### PR TITLE
In merge_spark_df_in_db make separation explicit in the operation condition to avoid ConcurrentAppendException

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@ History
 =======
 
 
+v0.20.7 (2023-12-14)
+
+* In merge_spark_df_in_db make separation explicit in the operation condition to avoid ConcurrentAppendException.
+
+
 v0.20.6 (2023-12-14)
 
 * Add stage_table optional argument to merge_spark_df_in_db ds.utils function.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r') as fileobj:
     long_description = fileobj.read()
 
 setup(name='aioradio',
-    version='0.20.6',
+    version='0.20.7',
     description='Generic asynchronous i/o python utilities for AWS services (SQS, S3, DynamoDB, Secrets Manager), Redis, MSSQL (pyodbc), JIRA and more',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
v0.20.7 (2023-12-14)

* In merge_spark_df_in_db make separation explicit in the operation condition to avoid ConcurrentAppendException.