### PR TITLE
Add quotes in match clause for merge_polars_in_db

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,17 @@ History
 =======
 
 
+v0.21.8 (2025-03-19)
+
+* Add quotes in match clause for merge_polars_in_db function, fixes an issue with merging when column names start with numbers.
+* Add convenience function scan_db_table that breaks down the catalog, schema and table.
+* Update aioboto3==14.1.0.
+* Update boto3==1.37.1.
+* Update botocore==1.37.1.
+* Update ddtrace==3.2.1.
+* Update polars==1.25.2.
+
+
 v0.21.7 (2025-03-03)
 
 * Add new ds utils function merge_polars_in_db to directly merge polars df into databricks unity catalog tables.

--- a/aioradio/requirements.txt
+++ b/aioradio/requirements.txt
@@ -1,11 +1,11 @@
-aioboto3==14.0.0
+aioboto3==14.1.0
 aiojobs==1.3.0
 backoff==2.2.1
-boto3==1.36.23
-botocore==1.36.23
+boto3==1.37.1
+botocore==1.37.1
 cython==3.0.12
 databricks-connect==14.3.1
-ddtrace==3.1.0
+ddtrace==3.2.1
 fakeredis==2.27.0
 faust-cchardet==2.1.19
 flask==3.1.0
@@ -18,11 +18,11 @@ numpy==2.0.2
 openpyxl==3.0.10
 orjson==3.9.15
 pandas==2.2.3
-polars==1.24.0
+polars==1.25.2
 pre-commit==3.8.0
 psycopg2-binary==2.9.10
 pyarrow==18.1.0
-pylint==3.3.4
+pylint==3.3.5
 pyodbc==5.2.0 --no-binary=pyodbc
 pysmb==1.2.10
 pyspark==3.5.5
@@ -31,7 +31,7 @@ pytest-asyncio==0.21.1
 pytest-cov==5.0.0
 python-json-logger==3.2.1
 redis==5.2.1
-setuptools==75.8.2
+setuptools==76.1.0
 twine==6.1.0
 typing_extensions==4.12.2
 werkzeug==3.1.3

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r', encoding='utf8') as fileobj:
     long_description = fileobj.read()
 
 setup(name='aioradio',
-    version='0.21.7',
+    version='0.21.8',
     description='Generic asynchronous i/o python utilities for AWS services (SQS, S3, DynamoDB, Secrets Manager), Redis, MSSQL (pyodbc), JIRA and more',
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -21,11 +21,11 @@ setup(name='aioradio',
     ],
     install_requires=[
         'cython>=0.29.33',
-        'aioboto3==14.0.0',
+        'aioboto3==14.1.0',
         'aiojobs>=1.0.0',
         'backoff>=2.1.2',
-        'botocore==1.36.23',
-        'boto3==1.36.23',
+        'botocore==1.37.1',
+        'boto3==1.37.1',
         'ddtrace>=0.60.1',
         'faust-cchardet>=2.1.18',
         'fakeredis>=2.20.0',


### PR DESCRIPTION
v0.21.8 (2025-03-19)

* Add quotes in match clause for merge_polars_in_db function, fixes an issue with merging when column names start with numbers.
* Add convenience function scan_db_table that breaks down the catalog, schema and table.
* Update aioboto3==14.1.0.
* Update boto3==1.37.1.
* Update botocore==1.37.1.
* Update ddtrace==3.2.1.
* Update polars==1.25.2.